### PR TITLE
Wrote a more complete contract for LengthAwarePaginator

### DIFF
--- a/src/BaseRepository.php
+++ b/src/BaseRepository.php
@@ -3,9 +3,11 @@ namespace Czim\Repository;
 
 use Czim\Repository\Contracts\BaseRepositoryInterface;
 use Czim\Repository\Contracts\CriteriaInterface;
+use Czim\Repository\Contracts\LengthAwarePaginatorInterface;
 use Czim\Repository\Criteria\NullCriteria;
 use Czim\Repository\Exceptions\RepositoryException;
 use Closure;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
@@ -225,7 +227,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
      * @param  array  $columns
      * @param  string $pageName
      * @param  null   $page
-     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     * @return LengthAwarePaginatorInterface|LengthAwarePaginator
      */
     public function paginate($perPage, $columns = ['*'], $pageName = 'page', $page = null)
     {

--- a/src/Contracts/LengthAwarePaginatorInterface.php
+++ b/src/Contracts/LengthAwarePaginatorInterface.php
@@ -1,0 +1,24 @@
+<?php
+namespace Czim\Repository\Contracts;
+
+use Illuminate\Contracts\Support\Htmlable;
+use Countable;
+use ArrayAccess;
+use JsonSerializable;
+use IteratorAggregate;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator as LengthAwarePaginatorContract;
+
+interface LengthAwarePaginatorInterface extends
+    LengthAwarePaginatorContract,
+    Arrayable,
+    ArrayAccess,
+    Countable,
+    IteratorAggregate,
+    JsonSerializable,
+    Jsonable,
+    Htmlable
+{
+
+}


### PR DESCRIPTION
The `paginate()` method of the BaseRepository class returns `Illuminate\Contracts\Pagination\LengthAwarePaginator` as the interface in the docblock. However, that interface is incomplete, because the actual `Illuminate\Pagination\LengthAwarePaginator` class implement many more methods, such as `count()`.