### PR TITLE
Pass id to ModelNotFoundException inside findOrFail

### DIFF
--- a/src/BaseRepository.php
+++ b/src/BaseRepository.php
@@ -266,7 +266,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
 
         if ( ! empty($result)) return $result;
 
-        throw (new ModelNotFoundException)->setModel($this->model());
+        throw (new ModelNotFoundException)->setModel($this->model(), $id);
     }
 
     /**


### PR DESCRIPTION
The default ModelNotFoundException allows for the ids to be passed by default which may be useful.