### PR TITLE
Update to support laravel 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
 

--- a/composer.json
+++ b/composer.json
@@ -21,16 +21,16 @@
     ],
     "require": {
         "php" : ">=7.1.3",
-        "illuminate/support": "^5.2",
-        "illuminate/database": "^5.2",
-        "myclabs/php-enum": "^1.4"
+        "illuminate/support": "^6.0",
+        "illuminate/database": "^6.0",
+        "myclabs/php-enum": "^1.7"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^7.0",
+        "phpunit/phpunit" : "^8.0",
         "scrutinizer/ocular": "~1.1",
-        "orchestra/testbench": "3.8.*",
+        "orchestra/testbench": "^4.0",
         "watson/rememberable": "dev-master",
-        "dimsav/laravel-translatable": "~9.0",
+        "astrotomic/laravel-translatable": "^11.5",
         "czim/laravel-listify": "~1.1.0"
     },
     "autoload": {

--- a/src/Criteria/Common/Scopes.php
+++ b/src/Criteria/Common/Scopes.php
@@ -2,6 +2,7 @@
 namespace Czim\Repository\Criteria\Common;
 
 use Czim\Repository\Criteria\AbstractCriteria;
+use Illuminate\Support\Arr;
 
 /**
  * Applies a bunch of scopes
@@ -51,7 +52,7 @@ class Scopes extends AbstractCriteria
             }
 
             // problems if the first param is not a string
-            if ( ! is_string(array_get($scopeSet, '0'))) {
+            if ( ! is_string(Arr::get($scopeSet, '0'))) {
                 throw new \Exception("First parameter of scopeset must be a string (the scope name)!");
             }
 

--- a/tests/CommonCriteriaTest.php
+++ b/tests/CommonCriteriaTest.php
@@ -109,7 +109,7 @@ class CommonCriteriaTest extends TestCase
     {
         $this->repository->pushCriteria(new OrderBy('position', 'desc'));
 
-        $this->assertArraySubset([3, 2, 1], $this->repository->lists('position'), "OrderBy Criteria doesn't work");
+        $this->assertEquals([3, 2, 1], $this->repository->lists('position'), "OrderBy Criteria doesn't work");
     }
 
     /**

--- a/tests/Helpers/TestExtendedModel.php
+++ b/tests/Helpers/TestExtendedModel.php
@@ -1,7 +1,7 @@
 <?php
 namespace Czim\Repository\Test\Helpers;
 
-use Dimsav\Translatable\Translatable;
+use Astrotomic\Translatable\Translatable;
 use Illuminate\Database\Eloquent\Model;
 use Czim\Listify\Listify;
 use Watson\Rememberable\Rememberable;


### PR DESCRIPTION
Hi, I modify some code to support laravel 6.0.

some package deprecate:

- dimsav/laravel-translatable use astrotomic/laravel-translatable instead.

some package update version

- orchestra/testbench
- myclabs/php-enum
- phpunit/phpunit

