### PR TITLE
Update some dependencies and support PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
         }
     ],
     "require": {
-        "php" : "^7.3|^8.0",
-        "illuminate/support": "^7.0|^8.0",
-        "illuminate/database": "^7.0|^8.0",
+        "php" : "^7.2|^8.0",
+        "illuminate/support": "^6.0|^7.0|^8.0",
+        "illuminate/database": "^6.0|^7.0|^8.0",
         "myclabs/php-enum": "^1.7"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,15 @@
         }
     ],
     "require": {
-        "php" : ">=7.2.0",
-        "illuminate/support": "^6.0|^7.0",
-        "illuminate/database": "^6.0|^7.0",
+        "php" : "^7.3|^8.0",
+        "illuminate/support": "^7.0|^8.0",
+        "illuminate/database": "^7.0|^8.0",
         "myclabs/php-enum": "^1.7"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^7.0|^8.0",
-        "orchestra/testbench": "^5.0",
-        "watson/rememberable": "^3.2|^4.0",
+        "phpunit/phpunit" : "^8.0|^9.0",
+        "orchestra/testbench": "^6.7.0",
+        "watson/rememberable": "^5.0.1",
         "astrotomic/laravel-translatable": "^11.8",
         "czim/laravel-listify": "^1.1|^2.0"
     },


### PR DESCRIPTION
Updated some package dependencies for Support Laravel 8. Also i bumped the supported php version and added php 8. 

Because following the following page. (https://www.php.net/supported-versions.php)
php 7.2 is not actively maintained anymore