### PR TITLE
Implement Laravel auto discovery.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,13 @@
     "scripts": {
         "test": "phpunit"
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Czim\\Repository\\RepositoryServiceProvider"
+            ]
+        }
+    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }


### PR DESCRIPTION
Because in newer Laravel versions they implemented auto discovery for packages. With this PR the package supports it. 

Kind regards, 
Tim Joosten 