### PR TITLE
Adds Laravel 12 support

### DIFF
--- a/.github/workflows/PHPUnit.yml
+++ b/.github/workflows/PHPUnit.yml
@@ -12,7 +12,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.0'
+                  php-version: "8.2"
                   extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
                   coverage: none
 

--- a/.github/workflows/PHPUnit.yml
+++ b/.github/workflows/PHPUnit.yml
@@ -20,11 +20,19 @@ jobs:
               run: |
                   sudo /etc/init.d/mysql start
                   mysql -u root -proot -e 'CREATE DATABASE IF NOT EXISTS laravel;'
-            - name: Cache composer dependencies
-              uses: actions/cache@v2
+
+            - name: Get Composer Cache Directory
+              id: composer-cache
+              run: |
+                  echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            - name: Cache Composer dependencies
+              uses: actions/cache@v4
               with:
-                  path: vendor
-                  key: composer-${{ hashFiles('composer.lock') }}
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-composer-
 
             - name: Run composer install
               run: composer install -n --prefer-dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 composer.lock
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ I prefer using them to make for easier unit testing in large projects.
 | 6.0        | 2.0      |
 | 7.0, 8.0   | 2.1      |
 | 9.0        | 3.0, 4.0 |
+| 10.0       | 4.2      |
+| 11.0       | 4.3      |
+| 12.0       | 4.4      |
 
 ### Warning
 

--- a/composer.json
+++ b/composer.json
@@ -20,19 +20,19 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "illuminate/support": "^10.0 || ^11.0 || ^12.0",
-        "illuminate/database": "^10.0 || ^11.0 || ^12.0",
+        "php": "^8.2",
+        "illuminate/support": "^11.0 || ^12.0",
+        "illuminate/database": "^11.0 || ^12.0",
         "myclabs/php-enum": "^1.7"
     },
     "require-dev": {
         "astrotomic/laravel-translatable": "^11.10",
         "czim/laravel-listify": "^2.0",
-        "orchestra/testbench": "^9.0",
-        "larastan/larastan": "^2.2",
-        "phpstan/phpstan-mockery": "^1.1",
-        "phpstan/phpstan-phpunit": "^1.1",
-        "phpunit/phpunit": "^11.0",
+        "orchestra/testbench": "^8.0 || ^9.0",
+        "larastan/larastan": "^2.10 || 3.3",
+        "phpstan/phpstan-mockery": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpunit/phpunit": "^10 || ^11.0",
         "watson/rememberable": "^6.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,19 +20,19 @@
         }
     ],
     "require": {
-        "php" : "^8.1",
-        "illuminate/support": "^9.0 || ^10.0 || ^11.0",
-        "illuminate/database": "^9.0 || ^10.0 || ^11.0",
+        "php": "^8.1",
+        "illuminate/support": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/database": "^10.0 || ^11.0 || ^12.0",
         "myclabs/php-enum": "^1.7"
     },
     "require-dev": {
         "astrotomic/laravel-translatable": "^11.10",
         "czim/laravel-listify": "^2.0",
-        "orchestra/testbench": "^8.0",
-        "nunomaduro/larastan": "^2.2",
+        "orchestra/testbench": "^9.0",
+        "larastan/larastan": "^2.2",
         "phpstan/phpstan-mockery": "^1.1",
         "phpstan/phpstan-phpunit": "^1.1",
-        "phpunit/phpunit" : "^9.5",
+        "phpunit/phpunit": "^11.0",
         "watson/rememberable": "^6.0"
     },
     "autoload": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,12 +1,9 @@
 includes:
-    - ./vendor/nunomaduro/larastan/extension.neon
+    - ./vendor/larastan/larastan/extension.neon
     - ./vendor/phpstan/phpstan-phpunit/extension.neon
     - ./vendor/phpstan/phpstan-mockery/extension.neon
 
 parameters:
+    level: 0
     paths:
         - src
-    ignoreErrors:
-        -
-            message: '#Call to an undefined method .*::remember\(\)#'
-            path: src/Criteria/Common/UseCache.php

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,7 @@
 >
     <testsuites>
         <testsuite name="Repository Package Test Suite">
-            <directory suffix=".php">./tests/</directory>
+            <directory suffix="Test.php">./tests/</directory>
             <exclude>./tests/TestCase.php</exclude>
         </testsuite>
     </testsuites>

--- a/src/Criteria/Common/UseCache.php
+++ b/src/Criteria/Common/UseCache.php
@@ -48,7 +48,7 @@ class UseCache extends AbstractCriteria
     protected function applyToQuery(
         Model|Relation|DatabaseBuilder|EloquentBuilder $model
     ): Model|Relation|DatabaseBuilder|EloquentBuilder {
-        /** @var $model RememberableBuilder */
+        /** @var RememberableBuilder $model */
         return $model->remember($this->timeToLive);
     }
 }


### PR DESCRIPTION
Hi @czim,

This PR adds support for Laravel 12 and bumps the relevant depenendencies.

I noticed during the Laravel 11 upgrade the github actions were broken, so I've fixed those as part of the patch to make sure there's visibility on tests passing, too.

I know you don't really recommend use of the package any more, but I've got a project still using this, so hoping you're open to the patch.

Thanks in advance.